### PR TITLE
Remove invalid neq operator

### DIFF
--- a/isla_lang.ott
+++ b/isla_lang.ott
@@ -213,7 +213,6 @@ bvcomp :: '' ::=
 % Operations that must be applied to exactly two elements
 binop :: '' ::=
   | =                                   :: :: Eq
-  | neq                                 :: :: Neq
   | bvarith                             :: :: Bvarith
   | bvcomp                              :: :: Bvcomp
 


### PR DESCRIPTION
This operator do not actually exists in SMTLIB, only in the `isla` internals. But `isla` print it at `(not (= ... ...))`