### PR TITLE
Use new stdpp-bitvector package instead of stdpp-unstable

### DIFF
--- a/coq-isla-lang.opam
+++ b/coq-isla-lang.opam
@@ -9,7 +9,7 @@ depends: [
   "dune" {>= "3.0"}
   "coq" {>= "8.13"}
   "coq-stdpp" {= "dev"}
-  "coq-stdpp-unstable" {= "dev"}
+  "coq-stdpp-bitvector" {= "dev"}
   "ott" {>= "0.33" & build}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -24,5 +24,5 @@
  (depends
   (coq (>= 8.13))
   (coq-stdpp (= dev))
-  (coq-stdpp-unstable (= dev))
+  (coq-stdpp-bitvector (= dev))
   (ott (and (>= 0.33) :build))))

--- a/isla_lang.ott
+++ b/isla_lang.ott
@@ -59,7 +59,7 @@
 embed {{ coq
 (*REAL_START*)
 From Coq Require Export String.
-From stdpp.unstable Require Export bitvector.
+From stdpp.bitvector Require Export definitions.
 
 Definition var_name : Set := Z.
 Bind Scope Z_scope with var_name.


### PR DESCRIPTION
This MR makes isla_lang.v compatible with recent versions of std++ / Iris.